### PR TITLE
[SP-3558] Refatora verificação de carregamento no footer

### DIFF
--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -16,17 +16,20 @@
         (click)="enviarMensagem($event)"
         [disabled]="!formIa.get('prompt')?.value ||
           formIa.get('prompt')?.value?.trim()?.length === 0 ||
-          (UtilsService.loading | async)"
+          isLoading()"
         matButton="filled">
         <mat-icon class="send-icon">send</mat-icon>
       </button>
       <button
         (click)="!isRecording ? startRecording() : stopRecording()"
-        [disabled]="(UtilsService.loading | async)"
+        [disabled]="isLoading()"
         matButton="filled">
         <mat-icon>{{ !isRecording ? 'mic' : 'stop' }}</mat-icon>
       </button>
-      <button (click)="selecionarArquivo()" [disabled]="(UtilsService.loading | async)" matButton="filled">
+      <button
+        (click)="selecionarArquivo()"
+        [disabled]="isLoading()"
+        matButton="filled">
         <mat-icon>attach_file</mat-icon>
       </button>
     </div>

--- a/src/app/components/footer/footer.ts
+++ b/src/app/components/footer/footer.ts
@@ -138,12 +138,20 @@ export class Footer implements OnInit {
    */
   protected enviarMensagem (event: Event): void {
     event?.preventDefault();
-    if ( UtilsService.loadingGeral.value ) {
+    if ( this.isLoading() ) {
       return;
     }
     const control: AbstractControl<any, any> | null = this.formIa.get('prompt');
     this.enviaMensagemUsuario.emit(control?.value);
     control?.setValue('');
+  }
+
+  /**
+   * Verifica se há carregamento em andamento.
+   * @returns {boolean} Indica se o sistema está carregando.
+   */
+  protected isLoading (): boolean {
+    return (UtilsService.loading.value || UtilsService.loadingGeral.value);
   }
 
   /**


### PR DESCRIPTION
Substitui a verificação direta por método `isLoading()` no footer. Isso melhora a legibilidade do código e facilita a manutenção. As alterações foram aplicadas nos métodos de envio de mensagem e interação com botões.